### PR TITLE
Add empty line in petroglyph command line script to fix flake8 issue

### DIFF
--- a/petroglyph/petroglyph
+++ b/petroglyph/petroglyph
@@ -11,6 +11,7 @@ parser.add_argument("--skin", default="monoblue", help="specify the skin to be u
 
 args = parser.parse_args()
 
+
 def init():
     from petroglyph import setup
     setup.init(args.skin)


### PR DESCRIPTION
This wasn't caught before because the file didn't have the .py
extension.
