### PR TITLE
Make arbitrary front matter data available as variables in template

### DIFF
--- a/petroglyph/generator.py
+++ b/petroglyph/generator.py
@@ -71,6 +71,7 @@ def generate(regenerate=False, dry_run=False):
                 'date': post.getmtime(),
                 'content': post.get_html()
             }
+            post_args.update(post.front_matter_data)
             if not dry_run:
                 if not new:
                     stats['regenerated_posts'] += 1
@@ -90,6 +91,7 @@ def generate(regenerate=False, dry_run=False):
                 ['<span class="tag">#' + tag + '</span>' for tag in post.tags]
             )
         }
+        post_peek_args.update(post.front_matter_data)
         post_previews_text.append(process_template(skin['post-peek'], post_peek_args))
     home_args = {
         'title': config['title'],

--- a/petroglyph/post.py
+++ b/petroglyph/post.py
@@ -22,6 +22,7 @@ class Post:
             raise ValueError("Empty YAML front-matter in '%s'." % file)
         if 'title' not in config:
             raise ValueError("'%s' does not have title in YAML front-matter." % file)
+        self.front_matter_data = config
         self.title = config['title']
         self.text = match.group(2)
         self.overrides = []


### PR DESCRIPTION
Any data that exists in a post's front matter is now made available to
the template using the normal {{variable}} syntax.
